### PR TITLE
feat: admin verify team and member document

### DIFF
--- a/src/controllers/api.controller.ts
+++ b/src/controllers/api.controller.ts
@@ -3,6 +3,7 @@ import { authProtectedRouter, authRouter } from './auth.controller';
 import { healthRouter } from './health.controller';
 import { mediaRouter } from './media.controller';
 import { teamMemberProtectedRouter } from './team-member.controller';
+import { teamProtectedRouter } from './team.controller';
 
 const unprotectedApiRouter = new OpenAPIHono();
 unprotectedApiRouter.route('/', healthRouter);
@@ -12,6 +13,7 @@ const protectedApiRouter = new OpenAPIHono();
 protectedApiRouter.route('/', authProtectedRouter);
 protectedApiRouter.route('/', mediaRouter);
 protectedApiRouter.route('/', teamMemberProtectedRouter);
+protectedApiRouter.route('/', teamProtectedRouter);
 
 export const apiRouter = new OpenAPIHono();
 apiRouter.route('/', unprotectedApiRouter);

--- a/src/controllers/team-member.controller.ts
+++ b/src/controllers/team-member.controller.ts
@@ -2,11 +2,13 @@ import { db } from '~/db/drizzle';
 import {
 	getTeamMemberById,
 	updateTeamMemberDocument,
+	updateTeamMemberVerification,
 } from '~/repositories/team-member.repository';
 import { getTeamById } from '~/repositories/team.repository';
 import {
 	getTeamMemberRoute,
 	postTeamMemberDocumentRoute,
+	postTeamMemberVerificationRoute,
 } from '~/routes/team-member.route';
 import { createAuthRouter } from '~/utils/router-factory';
 
@@ -52,4 +54,23 @@ teamMemberProtectedRouter.openapi(postTeamMemberDocumentRoute, async (c) => {
 	);
 
 	return c.json(updatedTeamMember, 200);
+});
+
+teamMemberProtectedRouter.openapi(postTeamMemberVerificationRoute, async (c) => {
+	const { competitionId, teamId, userId } = c.req.valid("param");
+
+  const team = await getTeamById(db, teamId, { competition: true, teamMember: true });
+  if (!team) return c.json({ error: "Team doesn't exist!" }, 400);
+
+  if (team.competition.id !== competitionId)
+    return c.json({ error: "Team and competition don't match!" }, 400);
+
+	if (!team.teamMembers.find((el) => el.userId === userId))
+		return c.json({ error: "User isn't inside team!" }, 403);
+
+  const body = c.req.valid("json");
+
+	await updateTeamMemberVerification(db, teamId, userId, body);
+
+  return c.json({ message: "Successfully updated document verification!" }, 200);
 });

--- a/src/controllers/team.controller.ts
+++ b/src/controllers/team.controller.ts
@@ -1,0 +1,22 @@
+import { db } from "~/db/drizzle";
+import { getTeamById, updateTeamVerification } from "~/repositories/team.repository";
+import { postTeamVerificationRoute } from "~/routes/team.route";
+import { createAuthRouter } from "~/utils/router-factory";
+
+export const teamProtectedRouter = createAuthRouter();
+
+teamProtectedRouter.openapi(postTeamVerificationRoute, async (c) => {
+  const { competitionId, teamId } = c.req.valid("param");
+
+  const team = await getTeamById(db, teamId, { competition: true });
+  if (!team) return c.json({ error: "Team doesn't exist!" }, 400);
+
+  if (team.competition.id !== competitionId)
+    return c.json({ error: "Team and competition don't match!" }, 400);
+
+  const body = c.req.valid("json");
+
+  await updateTeamVerification(db, teamId, body);
+
+  return c.json({ message: "Successfully updated team verification!" }, 200);
+});

--- a/src/repositories/team-member.repository.ts
+++ b/src/repositories/team-member.repository.ts
@@ -3,7 +3,7 @@ import type { z } from 'zod';
 import type { Database } from '~/db/drizzle';
 import { first } from '~/db/helper';
 import { teamMember } from '~/db/schema';
-import type { PostTeamMemberDocumentBodySchema } from '~/types/team-member.type';
+import type { PostTeamMemberDocumentBodySchema, PostTeamMemberVerificationBodySchema } from '~/types/team-member.type';
 import { insertMediaFromUrl } from './media.repository';
 
 export interface TeamMemberRelationOption {
@@ -61,3 +61,17 @@ export const updateTeamMemberDocument = async (
 		.returning()
 		.then(first);
 };
+
+export const updateTeamMemberVerification = async (
+	db: Database,
+	teamId: string,
+	userId: string,
+	data: z.infer<typeof PostTeamMemberVerificationBodySchema>,
+) => {
+	return await db
+		.update(teamMember)
+		.set(data)
+		.where(and(eq(teamMember.teamId, teamId), eq(teamMember.userId, userId)))
+		.returning()
+		.then(first);
+}

--- a/src/repositories/team.repository.ts
+++ b/src/repositories/team.repository.ts
@@ -2,6 +2,9 @@ import { eq } from 'drizzle-orm';
 import type { Database } from '~/db/drizzle';
 import { team } from '~/db/schema';
 import type { TeamMemberRelationOption } from './team-member.repository';
+import { first } from '~/db/helper';
+import { PostTeamVerificationBodySchema } from '~/types/team.type';
+import { z } from 'zod';
 
 interface TeamRelationOption {
 	teamMember?: TeamMemberRelationOption | boolean;
@@ -35,4 +38,17 @@ export const getTeamById = async (
 			paymentProof: options?.paymentProof ? true : undefined,
 		},
 	});
+};
+
+export const updateTeamVerification = async (
+	db: Database,
+	teamId: string,
+	data: z.infer<typeof PostTeamVerificationBodySchema>,
+) => {
+	return await db
+		.update(team)
+		.set(data)
+		.where(eq(team.id, teamId))
+		.returning()
+		.then(first);
 };

--- a/src/routes/team-member.route.ts
+++ b/src/routes/team-member.route.ts
@@ -1,6 +1,8 @@
 import { createRoute } from '@hono/zod-openapi';
 import {
+	CompetitionAndTeamAndUserIdParam,
 	PostTeamMemberDocumentBodySchema,
+	PostTeamMemberVerificationBodySchema,
 	TeamAndUserIdParam,
 	TeamMemberSchema,
 } from '~/types/team-member.type';
@@ -58,3 +60,28 @@ export const postTeamMemberDocumentRoute = createRoute({
 		500: createErrorResponse('GENERIC', 'Internal server error'),
 	},
 });
+
+export const postTeamMemberVerificationRoute = createRoute({
+  operationId: "postTeamMemberVerification",
+  tags: ["team-member"],
+  method: "post",
+  path: "/admin/{competitionId}/team/{teamId}/{userId}",
+  request: {
+		params: CompetitionAndTeamAndUserIdParam,
+		body: {
+			content: {
+				'application/json': {
+					schema: PostTeamMemberVerificationBodySchema
+				}
+			}
+		}
+  },
+  responses: {
+    200: {
+			description: "Succesfully updated document verification",
+    },
+    400: createErrorResponse("UNION", "Bad request error"),
+    500: createErrorResponse("GENERIC", "Internal server error"),
+  }
+});
+

--- a/src/routes/team.route.ts
+++ b/src/routes/team.route.ts
@@ -1,4 +1,6 @@
 import { createRoute } from '@hono/zod-openapi';
+import { CompetitionAndTeamIdParam, PostTeamVerificationBodySchema } from '~/types/team.type';
+import { createErrorResponse } from '~/utils/error-response-factory';
 
 export const joinTeamByCodeRoute = createRoute({
 	operationId: 'joinTeamByCode',
@@ -63,3 +65,28 @@ export const deleteTeamMemberRoute = createRoute({
 	path: '/team/{teamId}',
 	responses: {},
 });
+
+export const postTeamVerificationRoute = createRoute({
+  operationId: "postTeamVerification",
+  tags: ["team"],
+  method: "post",
+  path: "/admin/{competitionId}/team/{teamId}",
+  request: {
+		params: CompetitionAndTeamIdParam,
+		body: {
+			content: {
+				'application/json': {
+					schema: PostTeamVerificationBodySchema
+				}
+			}
+		}
+  },
+  responses: {
+    200: {
+			description: "Succesfully updated team verification",
+    },
+    400: createErrorResponse("UNION", "Bad request error"),
+    500: createErrorResponse("GENERIC", "Internal server error"),
+  }
+});
+

--- a/src/types/team-member.type.ts
+++ b/src/types/team-member.type.ts
@@ -37,3 +37,29 @@ export const PostTeamMemberDocumentBodySchema = createInsertSchema(
 	posterMediaId: true,
 	twibbonMediaId: true,
 });
+
+export const CompetitionAndTeamAndUserIdParam = z.object({
+  competitionId: z.string().openapi({
+    param: {
+      in: 'path',
+      required: true,
+    },
+  }),
+  teamId: z.string().openapi({
+    param: {
+      in: 'path',
+      required: true,
+    },
+  }),
+	userId: z.string().openapi({
+		param: {
+			in: 'path',
+			required: true,
+		},
+	}),
+});
+
+export const PostTeamMemberVerificationBodySchema = z.object({
+	isVerified: z.boolean(),
+	verificationError: z.string().optional(),
+});

--- a/src/types/team.type.ts
+++ b/src/types/team.type.ts
@@ -1,3 +1,23 @@
 import { z } from 'zod';
 
 export const TeamIdParam = z.object({ teamId: z.string() });
+
+export const CompetitionAndTeamIdParam = z.object({
+  competitionId: z.string().openapi({
+    param: {
+      in: 'path',
+      required: true,
+    },
+  }),
+  teamId: z.string().openapi({
+    param: {
+      in: 'path',
+      required: true,
+    },
+  }),
+});
+
+export const PostTeamVerificationBodySchema = z.object({
+  isVerified: z.boolean(),
+  verificationError: z.string().optional(),
+});


### PR DESCRIPTION
# Merge Request: Implement Team and Team Member Verification Endpoints  

## Description  
This merge request introduces two new endpoints for verifying team payments and team member documents. The endpoints allow admins to update the verification status and error messages for teams and team members in the database.

---

### 1. Verify Team Payment  
**Endpoint:**  
`POST api/admin/{competitionId}/team/{teamId}`  

**Payload:**  
```json
{
  "isVerified": false, // Required
  "verificationError": "Kurang Lengkap"// Optional
}
```

**Postman:**  
![image](https://github.com/user-attachments/assets/6e02faf7-fb7c-432f-a629-69c21d401505)

**Usecase:**  
- Team doesn't exists
![image](https://github.com/user-attachments/assets/248ce438-a048-4172-8206-cc6e3368eab3)

- Team doesn't match with the competition
![image](https://github.com/user-attachments/assets/f654513b-0e1e-44cc-a944-4c459f71f6b5)

- Requester is not an admin
_Not yet implemented because the admin router has not been developed._

### 2. Verify Team Member Documents
**Endpoint:**  
`POST api/admin/{competitionId}/team/{teamId}/{userId}`  

**Payload:**  
```json
{
  "isVerified": false, // Required
  "verificationError": "Kurang Lengkap"// Optional
}
```

**Postman:**  
![image](https://github.com/user-attachments/assets/b05a1063-c240-4af6-a64f-4fb38951075b)

**Usecase:**  
- Team doesn't exists
![image](https://github.com/user-attachments/assets/72cc4442-c15c-4f83-92e8-05163aae8f21)

- Team doesn't match with the competition
![image](https://github.com/user-attachments/assets/606054ab-a9ca-4e10-b2d6-44e357985a8d)

- The member isn't part of the team
![image](https://github.com/user-attachments/assets/8dd0f627-3145-4348-8f10-888cb6f07084)

- Requester is not an admin
_Not yet implemented because the admin router has not been developed._

**Notes**
The admin role validation will be added when the admin router is implemented.