### PR TITLE
Profile API and Role Middleware

### DIFF
--- a/drizzle/0002_flaky_loki.sql
+++ b/drizzle/0002_flaky_loki.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" ADD COLUMN "is_registration_complete" boolean DEFAULT false NOT NULL;

--- a/drizzle/0003_green_beyonder.sql
+++ b/drizzle/0003_green_beyonder.sql
@@ -1,0 +1,2 @@
+CREATE TYPE "public"."user_identity_role_enum" AS ENUM('admin', 'user');--> statement-breakpoint
+ALTER TABLE "user_identity" ADD COLUMN "role" "user_identity_role_enum" DEFAULT 'user' NOT NULL;

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,656 @@
+{
+  "id": "22f206d7-b664-4fcd-8beb-e146ddfce1a4",
+  "prevId": "b6b73fdb-3a7d-4c79-9714-f72bd4a52134",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.user_identity": {
+      "name": "user_identity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "user_identity_provider_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verification_token": {
+          "name": "verification_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_token_expiration": {
+          "name": "verification_token_expiration",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_recovery_token": {
+          "name": "password_recovery_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_recovery_token_expiration": {
+          "name": "password_recovery_token_expiration",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_identity_email_unique": {
+          "name": "user_identity_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition": {
+      "name": "competition",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_participants": {
+          "name": "max_participants",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_team_member": {
+          "name": "max_team_member",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guide_book_url": {
+          "name": "guide_book_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_creator_id_user_id_fk": {
+          "name": "media_creator_id_user_id_fk",
+          "tableFrom": "media",
+          "tableTo": "user",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "media_name_unique": {
+          "name": "media_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_member": {
+      "name": "team_member",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "team_member_role_renum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nisn_media_id": {
+          "name": "nisn_media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kartu_media_id": {
+          "name": "kartu_media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poster_media_id": {
+          "name": "poster_media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twibbon_media_id": {
+          "name": "twibbon_media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verification_error": {
+          "name": "verification_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_member_user_id_user_id_fk": {
+          "name": "team_member_user_id_user_id_fk",
+          "tableFrom": "team_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_member_team_id_team_id_fk": {
+          "name": "team_member_team_id_team_id_fk",
+          "tableFrom": "team_member",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_member_nisn_media_id_media_id_fk": {
+          "name": "team_member_nisn_media_id_media_id_fk",
+          "tableFrom": "team_member",
+          "tableTo": "media",
+          "columnsFrom": [
+            "nisn_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_member_kartu_media_id_media_id_fk": {
+          "name": "team_member_kartu_media_id_media_id_fk",
+          "tableFrom": "team_member",
+          "tableTo": "media",
+          "columnsFrom": [
+            "kartu_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_member_poster_media_id_media_id_fk": {
+          "name": "team_member_poster_media_id_media_id_fk",
+          "tableFrom": "team_member",
+          "tableTo": "media",
+          "columnsFrom": [
+            "poster_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_member_twibbon_media_id_media_id_fk": {
+          "name": "team_member_twibbon_media_id_media_id_fk",
+          "tableFrom": "team_member",
+          "tableTo": "media",
+          "columnsFrom": [
+            "twibbon_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team": {
+      "name": "team",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_code": {
+          "name": "team_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_proof_media_id": {
+          "name": "payment_proof_media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verification_error": {
+          "name": "verification_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_competition_id_competition_id_fk": {
+          "name": "team_competition_id_competition_id_fk",
+          "tableFrom": "team",
+          "tableTo": "competition",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_payment_proof_media_id_media_id_fk": {
+          "name": "team_payment_proof_media_id_media_id_fk",
+          "tableFrom": "team",
+          "tableTo": "media",
+          "columnsFrom": [
+            "payment_proof_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_team_code_unique": {
+          "name": "team_team_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "education": {
+          "name": "education",
+          "type": "user_education_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_source": {
+          "name": "entry_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance": {
+          "name": "instance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_line": {
+          "name": "id_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_discord": {
+          "name": "id_discord",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_instagram": {
+          "name": "id_instagram",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consent": {
+          "name": "consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_registration_complete": {
+          "name": "is_registration_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_id_user_identity_id_fk": {
+          "name": "user_id_user_identity_id_fk",
+          "tableFrom": "user",
+          "tableTo": "user_identity",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_identity_provider_enum": {
+      "name": "user_identity_provider_enum",
+      "schema": "public",
+      "values": [
+        "google",
+        "basic"
+      ]
+    },
+    "public.media_bucket_enum": {
+      "name": "media_bucket_enum",
+      "schema": "public",
+      "values": [
+        "competition-registration"
+      ]
+    },
+    "public.team_member_role_renum": {
+      "name": "team_member_role_renum",
+      "schema": "public",
+      "values": [
+        "leader",
+        "member"
+      ]
+    },
+    "public.user_education_enum": {
+      "name": "user_education_enum",
+      "schema": "public",
+      "values": [
+        "s1",
+        "s2",
+        "sma"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,672 @@
+{
+  "id": "c3e95f9c-c316-4d73-811e-4f75052bc45e",
+  "prevId": "22f206d7-b664-4fcd-8beb-e146ddfce1a4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.user_identity": {
+      "name": "user_identity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "user_identity_provider_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verification_token": {
+          "name": "verification_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verification_token_expiration": {
+          "name": "verification_token_expiration",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_recovery_token": {
+          "name": "password_recovery_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_recovery_token_expiration": {
+          "name": "password_recovery_token_expiration",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_identity_role_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_identity_email_unique": {
+          "name": "user_identity_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition": {
+      "name": "competition",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_participants": {
+          "name": "max_participants",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_team_member": {
+          "name": "max_team_member",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guide_book_url": {
+          "name": "guide_book_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_creator_id_user_id_fk": {
+          "name": "media_creator_id_user_id_fk",
+          "tableFrom": "media",
+          "tableTo": "user",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "media_name_unique": {
+          "name": "media_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_member": {
+      "name": "team_member",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "team_member_role_renum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nisn_media_id": {
+          "name": "nisn_media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kartu_media_id": {
+          "name": "kartu_media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poster_media_id": {
+          "name": "poster_media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twibbon_media_id": {
+          "name": "twibbon_media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verification_error": {
+          "name": "verification_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_member_user_id_user_id_fk": {
+          "name": "team_member_user_id_user_id_fk",
+          "tableFrom": "team_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_member_team_id_team_id_fk": {
+          "name": "team_member_team_id_team_id_fk",
+          "tableFrom": "team_member",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_member_nisn_media_id_media_id_fk": {
+          "name": "team_member_nisn_media_id_media_id_fk",
+          "tableFrom": "team_member",
+          "tableTo": "media",
+          "columnsFrom": [
+            "nisn_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_member_kartu_media_id_media_id_fk": {
+          "name": "team_member_kartu_media_id_media_id_fk",
+          "tableFrom": "team_member",
+          "tableTo": "media",
+          "columnsFrom": [
+            "kartu_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_member_poster_media_id_media_id_fk": {
+          "name": "team_member_poster_media_id_media_id_fk",
+          "tableFrom": "team_member",
+          "tableTo": "media",
+          "columnsFrom": [
+            "poster_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_member_twibbon_media_id_media_id_fk": {
+          "name": "team_member_twibbon_media_id_media_id_fk",
+          "tableFrom": "team_member",
+          "tableTo": "media",
+          "columnsFrom": [
+            "twibbon_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team": {
+      "name": "team",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_code": {
+          "name": "team_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_proof_media_id": {
+          "name": "payment_proof_media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verification_error": {
+          "name": "verification_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_competition_id_competition_id_fk": {
+          "name": "team_competition_id_competition_id_fk",
+          "tableFrom": "team",
+          "tableTo": "competition",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_payment_proof_media_id_media_id_fk": {
+          "name": "team_payment_proof_media_id_media_id_fk",
+          "tableFrom": "team",
+          "tableTo": "media",
+          "columnsFrom": [
+            "payment_proof_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_team_code_unique": {
+          "name": "team_team_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "team_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "education": {
+          "name": "education",
+          "type": "user_education_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_source": {
+          "name": "entry_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance": {
+          "name": "instance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_line": {
+          "name": "id_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_discord": {
+          "name": "id_discord",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_instagram": {
+          "name": "id_instagram",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consent": {
+          "name": "consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_registration_complete": {
+          "name": "is_registration_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_id_user_identity_id_fk": {
+          "name": "user_id_user_identity_id_fk",
+          "tableFrom": "user",
+          "tableTo": "user_identity",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_identity_provider_enum": {
+      "name": "user_identity_provider_enum",
+      "schema": "public",
+      "values": [
+        "google",
+        "basic"
+      ]
+    },
+    "public.user_identity_role_enum": {
+      "name": "user_identity_role_enum",
+      "schema": "public",
+      "values": [
+        "admin",
+        "user"
+      ]
+    },
+    "public.media_bucket_enum": {
+      "name": "media_bucket_enum",
+      "schema": "public",
+      "values": [
+        "competition-registration"
+      ]
+    },
+    "public.team_member_role_renum": {
+      "name": "team_member_role_renum",
+      "schema": "public",
+      "values": [
+        "leader",
+        "member"
+      ]
+    },
+    "public.user_education_enum": {
+      "name": "user_education_enum",
+      "schema": "public",
+      "values": [
+        "s1",
+        "s2",
+        "sma"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,20 +1,27 @@
 {
-	"version": "7",
-	"dialect": "postgresql",
-	"entries": [
-		{
-			"idx": 0,
-			"version": "7",
-			"when": 1733301282407,
-			"tag": "0000_large_forgotten_one",
-			"breakpoints": true
-		},
-		{
-			"idx": 1,
-			"version": "7",
-			"when": 1733319918722,
-			"tag": "0001_solid_gunslinger",
-			"breakpoints": true
-		}
-	]
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1733301282407,
+      "tag": "0000_large_forgotten_one",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1733319918722,
+      "tag": "0001_solid_gunslinger",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1733734643596,
+      "tag": "0002_flaky_loki",
+      "breakpoints": true
+    }
+  ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1733734643596,
       "tag": "0002_flaky_loki",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1733736913791,
+      "tag": "0003_green_beyonder",
+      "breakpoints": true
     }
   ]
 }

--- a/src/controllers/api.controller.ts
+++ b/src/controllers/api.controller.ts
@@ -4,6 +4,7 @@ import { healthRouter } from './health.controller';
 import { mediaRouter } from './media.controller';
 import { teamMemberProtectedRouter } from './team-member.controller';
 import { teamProtectedRouter } from './team.controller';
+import { userProtectedRouter } from './user.controller';
 
 const unprotectedApiRouter = new OpenAPIHono();
 unprotectedApiRouter.route('/', healthRouter);
@@ -15,6 +16,7 @@ protectedApiRouter.route('/', mediaRouter);
 protectedApiRouter.route('/', teamProtectedRouter);
 protectedApiRouter.route('/', teamMemberProtectedRouter);
 protectedApiRouter.route('/', teamProtectedRouter);
+protectedApiRouter.route('/', userProtectedRouter);
 
 export const apiRouter = new OpenAPIHono();
 apiRouter.route('/', unprotectedApiRouter);

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -31,6 +31,7 @@ import {
 import { GoogleTokenDataSchema, GoogleUserSchema } from '~/types/auth.type';
 import { UserSchema } from '~/types/user.type';
 import { createAuthRouter, createRouter } from '../utils/router-factory';
+import type { Context } from 'hono';
 
 const VERIFICATION_TOKEN_EXPIRATION_TIME = 360000; // TTL 1 hour
 
@@ -54,6 +55,37 @@ const generateRefreshToken = async (user: User) => {
 	};
 	const token = await jwt.sign(payload, env.REFRESH_TOKEN_SECRET);
 	return token;
+};
+
+const setCookiesToken = async (
+	c: Context,
+	user: User,
+	userIdentity: UserIdentity,
+) => {
+	const accessToken = await generateAccessToken(user, userIdentity);
+	const refreshToken = await generateRefreshToken(user);
+
+	await updateUserIdentity(db, user.id, {
+		refreshToken,
+	});
+
+	setCookie(c, 'khongguan', accessToken, {
+		path: '/',
+		secure: true,
+		httpOnly: true,
+		maxAge: env.ACCESS_TOKEN_EXPIRATION,
+		sameSite: 'None',
+	});
+
+	setCookie(c, 'saltcheese', refreshToken, {
+		path: '/',
+		secure: true,
+		httpOnly: true,
+		maxAge: env.REFRESH_TOKEN_EXPIRATION,
+		sameSite: 'None',
+	});
+
+	return { accessToken, refreshToken };
 };
 
 /** BASIC AUTHENTICATION ROUTES (Email & Password) */
@@ -114,21 +146,11 @@ authRouter.openapi(basicVerifyAccountRoute, async (c) => {
 		return c.json({ message: 'Something went wrong' }, 500);
 
 	// Login user
-	const accessToken = await generateAccessToken(user, userIdentity);
-	const refreshToken = await generateRefreshToken(user);
-
-	await updateUserIdentity(db, user.id, {
-		refreshToken,
-	});
-
-	setCookie(c, 'khongguan', accessToken, {
-		path: '/',
-		secure: true,
-		httpOnly: true,
-		maxAge: env.ACCESS_TOKEN_EXPIRATION,
-		sameSite: 'None',
-	});
-
+	const { accessToken, refreshToken } = await setCookiesToken(
+		c,
+		user,
+		userIdentity,
+	);
 	return c.json(
 		{
 			accessToken,
@@ -152,21 +174,11 @@ authRouter.openapi(basicLoginRoute, async (c) => {
 		return c.json({ message: "User isn't verified" }, 400);
 
 	// Login user
-	const accessToken = await generateAccessToken(user, userIdentity);
-	const refreshToken = await generateRefreshToken(user);
-
-	await updateUserIdentity(db, user.id, {
-		refreshToken,
-	});
-
-	setCookie(c, 'khongguan', accessToken, {
-		path: '/',
-		secure: true,
-		httpOnly: true,
-		maxAge: env.ACCESS_TOKEN_EXPIRATION,
-		sameSite: 'None',
-	});
-
+	const { accessToken, refreshToken } = await setCookiesToken(
+		c,
+		user,
+		userIdentity,
+	);
 	return c.json(
 		{
 			accessToken,
@@ -256,24 +268,11 @@ authRouter.openapi(googleAuthCallbackRoute, async (c) => {
 	)) as UserIdentity;
 	const existingUser = (await findUserByEmail(db, userInfo.email)) as User;
 
-	const accessToken = await generateAccessToken(
+	const { accessToken, refreshToken } = await setCookiesToken(
+		c,
 		existingUser,
 		existingUserIdentity,
 	);
-	const refreshToken = await generateRefreshToken(existingUser);
-
-	await updateUserIdentity(db, existingUser.id, {
-		refreshToken,
-	});
-
-	setCookie(c, 'khongguan', accessToken, {
-		path: '/',
-		secure: true,
-		httpOnly: true,
-		maxAge: env.ACCESS_TOKEN_EXPIRATION,
-		sameSite: 'None',
-	});
-
 	return c.json(
 		{
 			accessToken,
@@ -313,19 +312,15 @@ authRouter.openapi(refreshRoute, async (c) => {
 		return c.json({ message: "User isn't verified" }, 400);
 
 	// Login user
-	const accessToken = await generateAccessToken(user, userIdentity);
-
-	setCookie(c, 'khongguan', accessToken, {
-		path: '/',
-		secure: true,
-		httpOnly: true,
-		maxAge: env.ACCESS_TOKEN_EXPIRATION,
-		sameSite: 'None',
-	});
-
+	const { accessToken, refreshToken } = await setCookiesToken(
+		c,
+		user,
+		userIdentity,
+	);
 	return c.json(
 		{
 			accessToken,
+			refreshToken,
 		},
 		200,
 	);

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -28,11 +28,8 @@ import {
 	refreshRoute,
 	selfRoute,
 } from '~/routes/auth.route';
-import {
-	GoogleTokenDataSchema,
-	GoogleUserSchema,
-	UserSchema,
-} from '~/types/auth.type';
+import { GoogleTokenDataSchema, GoogleUserSchema } from '~/types/auth.type';
+import { UserSchema } from '~/types/user.type';
 import { createAuthRouter, createRouter } from '../utils/router-factory';
 
 const VERIFICATION_TOKEN_EXPIRATION_TIME = 360000; // TTL 1 hour

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -285,6 +285,7 @@ authRouter.openapi(googleAuthCallbackRoute, async (c) => {
 /** BOTH AUTH */
 authProtectedRouter.openapi(logoutRoute, async (c) => {
 	deleteCookie(c, 'khongguan');
+	deleteCookie(c, 'saltcheese');
 	await updateUserIdentity(db, c.var.user.id, {
 		refreshToken: null,
 	});

--- a/src/controllers/team-member.controller.ts
+++ b/src/controllers/team-member.controller.ts
@@ -1,4 +1,5 @@
 import { db } from '~/db/drizzle';
+import { roleMiddleware } from '~/middlewares/role-access.middleware';
 import {
 	getTeamMemberById,
 	updateTeamMemberDocument,

--- a/src/controllers/team-member.controller.ts
+++ b/src/controllers/team-member.controller.ts
@@ -56,6 +56,10 @@ teamMemberProtectedRouter.openapi(postTeamMemberDocumentRoute, async (c) => {
 	return c.json(updatedTeamMember, 200);
 });
 
+teamMemberProtectedRouter.post(
+	postTeamMemberVerificationRoute.getRoutingPath(),
+	roleMiddleware('admin'),
+);
 teamMemberProtectedRouter.openapi(
 	postTeamMemberVerificationRoute,
 	async (c) => {

--- a/src/controllers/team.controller.ts
+++ b/src/controllers/team.controller.ts
@@ -1,4 +1,5 @@
 import { db } from '~/db/drizzle';
+import { roleMiddleware } from '~/middlewares/role-access.middleware';
 import {
 	changeTeamName,
 	createTeam,
@@ -68,6 +69,10 @@ teamProtectedRouter.openapi(deleteTeamMemberRoute, async (c) => {
 	return c.json(member, 200);
 });
 
+teamProtectedRouter.post(
+	postTeamVerificationRoute.getRoutingPath(),
+	roleMiddleware('admin'),
+);
 teamProtectedRouter.openapi(postTeamVerificationRoute, async (c) => {
 	const { competitionId, teamId } = c.req.valid('param');
 

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -1,0 +1,34 @@
+import { db } from '~/db/drizzle';
+import { findUserById, updateUser } from '~/repositories/user.repository';
+import { getUserRoute, updateUserRoute } from '~/routes/user.route';
+import { createAuthRouter } from '~/utils/router-factory';
+
+export const userProtectedRouter = createAuthRouter();
+
+userProtectedRouter.openapi(getUserRoute, async (c) => {
+	const user = c.var.user;
+	const findUser = await findUserById(db, user.id);
+	if (!findUser) return c.json({ message: 'User not found!' }, 400);
+	return c.json(findUser, 200);
+});
+
+userProtectedRouter.openapi(updateUserRoute, async (c) => {
+	const body = c.req.valid('json');
+	const user = await findUserById(db, c.var.user.id);
+	
+	if (!user) return c.json({ message: 'User not found!' }, 400);
+	// Kalau udah 'isRegistrationComplete' consent gak boleh diubah
+	if (user.isRegistrationComplete && typeof body.consent === 'boolean')
+		return c.json({ message: 'You cannot change consent.' }, 400);
+
+	const values = {
+		...body,
+		isRegistrationComplete: !user.isRegistrationComplete
+			? true
+			: user.isRegistrationComplete,
+		consent: !user.isRegistrationComplete ? body.consent : user.consent,
+	};
+
+	const updatedUser = await updateUser(db, user.id, values);
+	return c.json(updatedUser, 200);
+});

--- a/src/db/schema/auth.schema.ts
+++ b/src/db/schema/auth.schema.ts
@@ -12,6 +12,11 @@ export const userIdentityProviderEnum = pgEnum('user_identity_provider_enum', [
 	'basic',
 ]);
 
+export const userIdentityRoleEnum = pgEnum('user_identity_role_enum', [
+	'admin',
+	'user',
+]);
+
 export const userIdentity = pgTable('user_identity', {
 	id: text('id').primaryKey().$defaultFn(createId),
 	email: text('email').unique().notNull(),
@@ -31,6 +36,8 @@ export const userIdentity = pgTable('user_identity', {
 
 	refreshToken: text('refresh_token'),
 
+	role: userIdentityRoleEnum('role').default('user').notNull(),
+
 	createdAt: timestamp('created_at').defaultNow(),
 	updatedAt: timestamp('updated_at').$onUpdate(getNow),
 });
@@ -41,3 +48,5 @@ export const userIdentityRelations = relations(userIdentity, ({ one }) => ({
 
 export type UserIdentity = InferSelectModel<typeof userIdentity>;
 export type UserIdentityInsert = InferInsertModel<typeof userIdentity>;
+export type UserIdentityRolesEnum = (typeof userIdentityRoleEnum.enumValues)[number];
+

--- a/src/db/schema/user.schema.ts
+++ b/src/db/schema/user.schema.ts
@@ -32,6 +32,9 @@ export const user = pgTable('user', {
 	idDiscord: text('id_discord'),
 	idInstagram: text('id_instagram'),
 	consent: boolean('consent').notNull().default(false),
+	isRegistrationComplete: boolean('is_registration_complete')
+		.notNull()
+		.default(false),
 	createdAt: timestamp('created_at').defaultNow(),
 	updatedAt: timestamp('updated_at').$onUpdate(getNow),
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ app.doc('/openapi.json', {
 		{ name: 'team', description: 'Team API' },
 		{ name: 'team-member', description: 'Team Member API' },
 		{ name: 'admin', description: 'Admin API' },
+		{ name: 'user', description: 'User API' },
 	],
 });
 

--- a/src/middlewares/role-access.middleware.ts
+++ b/src/middlewares/role-access.middleware.ts
@@ -1,0 +1,24 @@
+import { createFactory } from 'hono/factory';
+import type { z } from 'zod';
+import { db } from '~/db/drizzle';
+import type { UserIdentityRolesEnum } from '~/db/schema';
+import { findUserIdentityById } from '~/repositories/auth.repository';
+import type { JWTPayloadSchema } from '~/types/auth.type';
+
+const factory = createFactory<{
+	Variables: {
+		user: z.infer<typeof JWTPayloadSchema>;
+	};
+}>();
+
+export const roleMiddleware = (requestedRole: UserIdentityRolesEnum) => {
+	return factory.createMiddleware(async (c, next) => {
+		const role = (await findUserIdentityById(db, c.var.user.id))?.role;
+
+		if (role !== requestedRole) {
+			return c.json({ message: 'Unauthorized' }, 403);
+		}
+
+		await next();
+	});
+};

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -3,7 +3,7 @@ import type { z } from 'zod';
 import type { Database } from '~/db/drizzle';
 import { first } from '~/db/helper';
 import { user } from '~/db/schema/user.schema';
-import type { UserUpdateSchema } from '~/types/auth.type';
+import type { UserUpdateSchema } from '~/types/user.type';
 
 export const findUserByEmail = async (db: Database, email: string) => {
 	return db.select().from(user).where(eq(user.email, email)).then(first);

--- a/src/routes/auth.route.ts
+++ b/src/routes/auth.route.ts
@@ -178,7 +178,7 @@ export const refreshRoute = createRoute({
 			description: 'Refresh access token,',
 			content: {
 				'application/json': {
-					schema: AccessTokenSchema,
+					schema: AccessRefreshTokenSchema,
 				},
 			},
 		},

--- a/src/routes/auth.route.ts
+++ b/src/routes/auth.route.ts
@@ -7,8 +7,8 @@ import {
 	BasicVerifyAccountQuerySchema,
 	GoogleCallbackQuerySchema,
 	RefreshTokenQuerySchema,
-	UserSchema,
 } from '~/types/auth.type';
+import { UserSchema } from '~/types/user.type';
 import { createErrorResponse } from '../utils/error-response-factory';
 
 /** BASIC AUTHENTICATION ROUTES (Email & Password) */

--- a/src/routes/team-member.route.ts
+++ b/src/routes/team-member.route.ts
@@ -63,7 +63,7 @@ export const postTeamMemberDocumentRoute = createRoute({
 
 export const postTeamMemberVerificationRoute = createRoute({
 	operationId: 'postTeamMemberVerification',
-	tags: ['team-member'],
+	tags: ['team-member', 'admin'],
 	method: 'post',
 	path: '/admin/{competitionId}/team/{teamId}/{userId}',
 	request: {

--- a/src/routes/user.route.ts
+++ b/src/routes/user.route.ts
@@ -1,0 +1,54 @@
+import { createRoute } from '@hono/zod-openapi';
+import {
+	UpdateUserBodyRoute,
+	UserSchema,
+	UserUpdateSchema,
+} from '~/types/user.type';
+import { createErrorResponse } from '~/utils/error-response-factory';
+
+export const getUserRoute = createRoute({
+	operationId: 'getUser',
+	tags: ['user'],
+	method: 'get',
+	path: '/user',
+	responses: {
+		200: {
+			description: 'Fetched currently logged in user.',
+			content: {
+				'application/json': {
+					schema: UserSchema,
+				},
+			},
+		},
+		400: createErrorResponse('UNION', 'Bad request error'),
+		500: createErrorResponse('GENERIC', 'Internal server error'),
+	},
+});
+
+export const updateUserRoute = createRoute({
+	operationId: 'updateUser',
+	tags: ['user'],
+	method: 'put',
+	path: '/user',
+	request: {
+		body: {
+			content: {
+				'application/json': {
+					schema: UpdateUserBodyRoute,
+				},
+			},
+		},
+	},
+	responses: {
+		200: {
+			description: 'Updates currenly logged in user profile.',
+			content: {
+				'application/json': {
+					schema: UserSchema,
+				},
+			},
+		},
+		400: createErrorResponse('UNION', 'Bad request error'),
+		500: createErrorResponse('GENERIC', 'Internal server error'),
+	},
+});

--- a/src/types/auth.type.ts
+++ b/src/types/auth.type.ts
@@ -1,19 +1,12 @@
 import { z } from '@hono/zod-openapi';
 import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
 import { userIdentity } from '~/db/schema/auth.schema';
-import { user } from '~/db/schema/user.schema';
+import { UserSchema } from './user.type';
 
 export const UserIdentitySchema = createSelectSchema(userIdentity);
 
 export const UserIdentityUpdateSchema =
 	createInsertSchema(userIdentity).partial();
-
-export const UserSchema = createSelectSchema(user, {
-	createdAt: z.union([z.string(), z.date()]),
-	updatedAt: z.union([z.string(), z.date()]),
-}).openapi('User');
-
-export const UserUpdateSchema = createInsertSchema(user).partial();
 
 export const JWTPayloadSchema = UserSchema.merge(
 	UserIdentitySchema.pick({ provider: true }),

--- a/src/types/user.type.ts
+++ b/src/types/user.type.ts
@@ -1,0 +1,18 @@
+import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
+import { z } from 'zod';
+import { user } from '~/db/schema';
+
+export const UserSchema = createSelectSchema(user, {
+	createdAt: z.union([z.string(), z.date()]),
+	updatedAt: z.union([z.string(), z.date()]),
+}).openapi('User');
+
+export const UserUpdateSchema = createInsertSchema(user).partial();
+
+export const UpdateUserBodyRoute = UserUpdateSchema.omit({
+	id: true,
+	email: true,
+	createdAt: true,
+	updatedAt: true,
+	isRegistrationComplete: true,
+});


### PR DESCRIPTION
## Profile API and Role Middleware
### Features
- New routes for /api/user to get and update currently logged in user profile
- Add middleware for role access control (currently `[admin, user]`)
- Restrict admin route (verify documents) to admin onyl
- Refactor setting cookies inside a function
- Set refresh token to cookies aswell (saltcheese)

### Schema Changes
- New `role` attribute on UserIdentity