### PR TITLE
Admin Competition Announcement API

### DIFF
--- a/src/controllers/api.controller.ts
+++ b/src/controllers/api.controller.ts
@@ -5,6 +5,7 @@ import { mediaRouter } from './media.controller';
 import { teamMemberProtectedRouter } from './team-member.controller';
 import { teamProtectedRouter } from './team.controller';
 import { userProtectedRouter } from './user.controller';
+import { competitionProtectedRouter } from './competition.controller';
 
 const unprotectedApiRouter = new OpenAPIHono();
 unprotectedApiRouter.route('/', healthRouter);
@@ -17,6 +18,7 @@ protectedApiRouter.route('/', teamProtectedRouter);
 protectedApiRouter.route('/', teamMemberProtectedRouter);
 protectedApiRouter.route('/', teamProtectedRouter);
 protectedApiRouter.route('/', userProtectedRouter);
+protectedApiRouter.route('/', competitionProtectedRouter);
 
 export const apiRouter = new OpenAPIHono();
 apiRouter.route('/', unprotectedApiRouter);

--- a/src/controllers/competition.controller.ts
+++ b/src/controllers/competition.controller.ts
@@ -1,0 +1,59 @@
+import { db } from '~/db/drizzle';
+import { createAuthRouter } from '~/utils/router-factory';
+import { roleMiddleware } from '~/middlewares/role-access.middleware';
+import {
+	getAnnouncementsByCompetitionId,
+	getCompetition,
+	postAnnouncement,
+} from '~/repositories/competition.repository';
+import {
+	getAdminCompAnnouncementRoute,
+	postAdminCompAnnouncementRoute,
+} from '~/routes/competition.route';
+
+export const competitionProtectedRouter = createAuthRouter();
+
+competitionProtectedRouter.get(
+	getAdminCompAnnouncementRoute.getRoutingPath(),
+	roleMiddleware('admin'),
+);
+competitionProtectedRouter.openapi(getAdminCompAnnouncementRoute, async (c) => {
+	const { competitionId } = c.req.valid('param');
+
+	// Check if competition exists
+	const competition = await getCompetition(db, competitionId);
+	if (!competition) return c.json({ error: "Competition doesn't exist!" }, 400);
+
+	const announcements = await getAnnouncementsByCompetitionId(
+		db,
+		competitionId,
+	);
+	return c.json(announcements, 200);
+});
+
+competitionProtectedRouter.post(
+	postAdminCompAnnouncementRoute.getRoutingPath(),
+	roleMiddleware('admin'),
+);
+competitionProtectedRouter.openapi(
+	postAdminCompAnnouncementRoute,
+	async (c) => {
+		const { competitionId } = c.req.valid('param');
+		const body = c.req.valid('json');
+
+		// Check if competition exists
+		const competition = await getCompetition(db, competitionId);
+		if (!competition)
+			return c.json({ error: "Competition doesn't exist!" }, 400);
+
+		// Create announcement
+		const user = c.var.user;
+		const announcement = await postAnnouncement(
+			db,
+			competitionId,
+			user.id,
+			body,
+		);
+		return c.json(announcement, 200);
+	},
+);

--- a/src/db/schema/competition.schema.ts
+++ b/src/db/schema/competition.schema.ts
@@ -92,9 +92,9 @@ export const competitionSubmissionRelations = relations(
 			fields: [competitionSubmission.competitionId],
 			references: [competition.id],
 		}),
-		team: one(user, {
+		team: one(team, {
 			fields: [competitionSubmission.teamId],
-			references: [user.id],
+			references: [team.id],
 		}),
 		file: one(media, {
 			fields: [competitionSubmission.mediaId],

--- a/src/repositories/competition.repository.ts
+++ b/src/repositories/competition.repository.ts
@@ -49,17 +49,14 @@ export const postAnnouncement = async (
 	authorId: string,
 	body: z.infer<typeof PostCompAnnouncementBodySchema>,
 ) => {
-	return await db.transaction(async (trx) => {
-		const announcement = await trx
-			.insert(competitionAnnouncement)
-			.values({
-				competitionId: competitionId,
-				authorId: authorId,
-				title: body.title,
-				description: body.description,
-			})
-			.returning()
-			.then(first);
-		return announcement;
-	});
+	return await db
+		.insert(competitionAnnouncement)
+		.values({
+			competitionId: competitionId,
+			authorId: authorId,
+			title: body.title,
+			description: body.description,
+		})
+		.returning()
+		.then(first);
 };

--- a/src/repositories/competition.repository.ts
+++ b/src/repositories/competition.repository.ts
@@ -1,6 +1,9 @@
 import { eq } from 'drizzle-orm';
 import type { Database } from '../db/drizzle';
-import { competition, team } from '../db/schema';
+import { competition, competitionAnnouncement, team } from '../db/schema';
+import type { PostCompAnnouncementBodySchema } from '~/types/competition.type';
+import type { z } from 'zod';
+import { first } from '~/db/helper';
 
 export const getCompetitionParticipantNumber = async (
 	db: Database,
@@ -21,4 +24,42 @@ export const getCompetitionById = async (
 	});
 
 	return { maxParticipants: result?.maxParticipants };
+};
+
+export const getCompetition = async (db: Database, competitionId: string) => {
+	const result = await db.query.competition.findFirst({
+		where: eq(competition.id, competitionId),
+	});
+	return result;
+};
+
+export const getAnnouncementsByCompetitionId = async (
+	db: Database,
+	competitionId: string,
+) => {
+	const result = await db.query.competitionAnnouncement.findMany({
+		where: eq(competitionAnnouncement.competitionId, competitionId),
+	});
+	return result;
+};
+
+export const postAnnouncement = async (
+	db: Database,
+	competitionId: string,
+	authorId: string,
+	body: z.infer<typeof PostCompAnnouncementBodySchema>,
+) => {
+	return await db.transaction(async (trx) => {
+		const announcement = await trx
+			.insert(competitionAnnouncement)
+			.values({
+				competitionId: competitionId,
+				authorId: authorId,
+				title: body.title,
+				description: body.description,
+			})
+			.returning()
+			.then(first);
+		return announcement;
+	});
 };

--- a/src/routes/competition.route.ts
+++ b/src/routes/competition.route.ts
@@ -1,0 +1,60 @@
+import { createRoute } from '@hono/zod-openapi';
+import {
+	AnnouncementSchema,
+	PostCompAnnouncementBodySchema,
+} from '~/types/competition.type';
+import { AllAnnouncementSchema } from '~/types/competition.type';
+import { CompetitionIdParam } from '~/types/competition.type';
+import { createErrorResponse } from '~/utils/error-response-factory';
+
+export const getAdminCompAnnouncementRoute = createRoute({
+	operationId: 'getAdminCompAnnouncement',
+	tags: ['admin', 'competition'],
+	method: 'get',
+	path: '/admin/{competitionId}/announcement',
+	request: {
+		params: CompetitionIdParam,
+	},
+	responses: {
+		200: {
+			content: {
+				'application/json': {
+					schema: AllAnnouncementSchema,
+				},
+			},
+			description: 'Succesfully fetched all announcements',
+		},
+		400: createErrorResponse('UNION', 'Bad request error'),
+		500: createErrorResponse('GENERIC', 'Internal server error'),
+	},
+});
+
+export const postAdminCompAnnouncementRoute = createRoute({
+	operationId: 'postAdminCompAnnouncement',
+	tags: ['admin', 'competition'],
+	method: 'post',
+	path: '/api/admin/{competitionId}/announcement',
+	request: {
+		params: CompetitionIdParam,
+		body: {
+			content: {
+				'application/json': {
+					schema: PostCompAnnouncementBodySchema,
+				},
+			},
+			required: true,
+		},
+	},
+	responses: {
+		200: {
+			content: {
+				'application/json': {
+					schema: AnnouncementSchema,
+				},
+			},
+			description: 'Succesfully posted announcement',
+		},
+		400: createErrorResponse('UNION', 'Bad request error'),
+		500: createErrorResponse('GENERIC', 'Internal server error'),
+	},
+});

--- a/src/types/competition.type.ts
+++ b/src/types/competition.type.ts
@@ -1,0 +1,23 @@
+import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
+import { z } from 'zod';
+import { competitionAnnouncement } from '~/db/schema';
+
+export const AnnouncementSchema = createSelectSchema(competitionAnnouncement, {
+	createdAt: z.union([z.string(), z.date()]),
+}).openapi('Announcement');
+
+export const AllAnnouncementSchema = z.array(AnnouncementSchema);
+
+export const CompetitionIdParam = z.object({
+	competitionId: z.string().openapi({
+		param: {
+			in: 'path',
+			required: true,
+		},
+	}),
+});
+
+export const PostCompAnnouncementBodySchema = z.object({
+	title: z.string().min(1),
+	description: z.string().min(1),
+});


### PR DESCRIPTION
## Get Competition Announcement

### example

**Params**
`{ "competitionId": "abcdefgh" }`

![image](https://github.com/user-attachments/assets/fe8eb53a-0fcb-4c1e-b1b5-deb026a74293)

**Use case:**
1. Handling role isn't admin  
![image](https://github.com/user-attachments/assets/ddbf8f8f-e86d-4d31-ae7c-090d90a1e460)
2. Handling competition doesn't exist
![image](https://github.com/user-attachments/assets/db706c63-751d-4b90-b530-0893700e1b86)


## Post Competition Announcement

### example

**Params**
`{ "competitionId": "abcdefgh" }`

**Body Request**
`
{
    "title": "halo",
    "description":  "coba"
}
`

![image](https://github.com/user-attachments/assets/19c96878-e48d-4baa-a074-90f247c80c07)

**Use case:**
1. Handling role isn't admin  
![image](https://github.com/user-attachments/assets/f1c4d61a-1c9f-409d-b1e5-00a4143dba5d)

2. Handling empty title or description
![image](https://github.com/user-attachments/assets/dc1f43e8-1866-4f76-a19d-6c233a2dfb0b)

3. Handling competition doesn't exist
![image](https://github.com/user-attachments/assets/b884d02a-62e2-4ec5-96ea-42ff3e23ecfd)

### Notes:
1. Updated competition schema on `competitionSubmissionRelations` from referencing `user` to referencing `team` to resolve error when running drizzle studio
![image](https://github.com/user-attachments/assets/813ba4c5-3881-496f-94ef-d1225e564fc2)

 